### PR TITLE
docs: correct run command for iOS

### DIFF
--- a/New-Architecture/How-to-Enable-New-Architecture.md
+++ b/New-Architecture/How-to-Enable-New-Architecture.md
@@ -78,7 +78,7 @@ Navigate to the **ios directory** and run the following:
 
 Then build and run the app as usual:
 
-    npx react-native run-android
+    npx react-native run-ios
 
 > NOTE: In future when you do a pod install command then all new architecture code will be removed from pod file.
 


### PR DESCRIPTION
Corrected the build command for iOS in the README to ensure accurate build instructions.